### PR TITLE
fix: stop the mouse hook thread from stalling all system input

### DIFF
--- a/backend/electron-main.js
+++ b/backend/electron-main.js
@@ -1597,9 +1597,18 @@ function showMenuAtCursor(source = "shortcut") {
 }
 
 /**
- * Em `small` não há absolutamente nada para desenhar — o HWND encolhe ao canto e é escondido.
- * Deixá-lo ao tamanho do monitor mantinha uma janela layered topmost que o DWM compõe em cada frame
- * e que recebe todo o hit-testing do rato: ~22% de `dwm|3d`, com cursor e arrasto lentos em todo o sistema.
+ * Em `small` não há nada para desenhar, mas o HWND NÃO é escondido nem encolhido: `smallModeBounds`
+ * mantém-no nos bounds do radial (988×988, centrado) e visível — ver "Repouso estável" mais abaixo,
+ * que troca isso por não precisar de hide/show nem resize ao abrir. Este comentário descrevia o
+ * comportamento antigo e ficou a mentir durante várias investigações de lag; a redação anterior era
+ * "o HWND encolhe ao canto e é escondido".
+ *
+ * O risco que o texto antigo descrevia é real mas é de COMPOSIÇÃO (DWM/MPO), não de input: uma
+ * janela layered topmost ao tamanho do monitor fá-la compor em cada frame. Medido nesta máquina, a
+ * caixa de 988×988 em repouso não move a agulha do `dwm` (4,5% -> 4,3%, dentro do ruído). Se algum
+ * dia se quiser mesmo eliminá-la, estacionar os bounds fora do desktop visível preserva a
+ * superfície quente; esconder reintroduz o flash de textura obsoleta que o handshake de abertura
+ * existe para evitar.
  *
  * Existia aqui uma flag `overlayHudActive` para o caso de haver um HUD (faixa de Pomodoro/Cronómetro).
  * Além de os widgets já não existirem, a flag causava um artefacto: ao FECHAR o radial, o renderer
@@ -2607,9 +2616,17 @@ function configureAutoUpdates() {
 }
 
 app.whenReady().then(async () => {
-  /** Compila/inicializa o helper em repouso; ao abrir o radial o bloqueio entra sem atraso. */
-  ensureRadialMouseBlocker();
   if (!gotTheLock) return;
+
+  /**
+   * Compila/inicializa o helper em repouso; ao abrir o radial o bloqueio entra sem atraso.
+   *
+   * DEPOIS do `gotTheLock`: uma segunda instância vai fechar-se a seguir, e arrancar aqui o
+   * helper deixava um `powershell` com um hook WH_MOUSE_LL global pendurado no arranque que foi
+   * rejeitado. `setRadialMouseBlocking` e `setRadialTriggerCapture` também o garantem, por isso
+   * esta chamada é só aquecimento — nunca a única.
+   */
+  ensureRadialMouseBlocker();
 
   configureAutoUpdates();
 
@@ -4490,7 +4507,8 @@ app.whenReady().then(async () => {
     return isDev ? p : p.replace("app.asar", "app.asar.unpacked");
   };
 
-  // 2. PowerShell middle-button monitor (GetAsyncKeyState; never intercepts cursor movement)
+  // 2. Captura do botão do meio pelo hook WH_MOUSE_LL global em `backend/mouse-blocker.ps1`.
+  //    NÃO é sondagem: o hook vê todos os eventos de rato do sistema, movimento incluído.
   let mouseHook = null;
   /** Botão com que a sonda atual foi lançada — comparado para saber se é preciso relançá-la. */
   let activeMouseHookButton = "middle";
@@ -4712,8 +4730,16 @@ app.whenReady().then(async () => {
   stopMouseHookForShutdown = stopMouseHook;
 
   syncMouseHookState = () => {
-    // MMB remains global, but uses GetAsyncKeyState polling rather than WH_MOUSE_LL. The old
-    // low-level hook was invoked synchronously for every pointer movement and could delay the cursor.
+    /**
+     * O gatilho É um hook WH_MOUSE_LL global (`backend/mouse-blocker.ps1`), não sondagem — este
+     * comentário afirmava o contrário e foi por isso que uma regressão de lag global sobreviveu a
+     * várias investigações. Tem de ser o hook a detetar E a engolir: um poller `GetAsyncKeyState`
+     * só observava, o clique seguia para a janela por baixo e o Windows entrava em autoscroll.
+     *
+     * INVARIANTE: nada que bloqueie, aloque ou enumere pode correr no thread que serve esse hook —
+     * todo o rato do sistema passa por lá, serializado. Um watchdog de 15 ms que chamava
+     * `Process.GetProcessById` custava 12 ms por tique e engasgava o ecrã inteiro.
+     */
     const wantHook = cachedRadialFlags.enableMouseTrigger;
     /** Trocar de botão exige relançar a sonda: o VK é passado no arranque do processo. */
     /** Botao OU modo: ambos vao no comando TRIGGER, logo qualquer um exige re-armar a captura. */

--- a/backend/mouse-blocker.ps1
+++ b/backend/mouse-blocker.ps1
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 
 public static class ZenithRadialMouseBlocker {
     private const int WH_MOUSE_LL = 14;
+    private const int WM_MOUSEMOVE = 0x0200;
     private const int WM_LBUTTONDOWN = 0x0201;
     private const int WM_LBUTTONUP = 0x0202;
     private const int WM_LBUTTONDBLCLK = 0x0203;
@@ -28,6 +29,9 @@ public static class ZenithRadialMouseBlocker {
     private const int MOUSEEVENTF_MIDDLEUP = 0x0040;
     private const int MOUSEEVENTF_XDOWN = 0x0080;
     private const int MOUSEEVENTF_XUP = 0x0100;
+
+    private const uint SYNCHRONIZE = 0x00100000;
+    private const uint INFINITE = 0xFFFFFFFF;
 
     /** Assinatura dos eventos que nos proprios injetamos, para o hook nao os voltar a engolir. */
     private const uint SYNTHETIC_TAG = 0x524F5659;
@@ -64,15 +68,31 @@ public static class ZenithRadialMouseBlocker {
     private static extern IntPtr GetModuleHandle(string moduleName);
     [DllImport("user32.dll", SetLastError = true)]
     private static extern uint SendInput(uint count, INPUT[] inputs, int size);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint access, bool inheritHandle, int processId);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
 
     private static readonly ConcurrentQueue<string> Commands = new ConcurrentQueue<string>();
     private static readonly ConcurrentQueue<int> Passthroughs = new ConcurrentQueue<int>();
+    private static readonly ConcurrentQueue<string> Outbound = new ConcurrentQueue<string>();
+    private static readonly AutoResetEvent OutboundSignal = new AutoResetEvent(false);
     private static readonly LowLevelMouseProc Callback = HookCallback;
-    private static readonly object WriteLock = new object();
     private static IntPtr Hook = IntPtr.Zero;
     private static volatile bool Blocking;
     private static int Left, Top, Right, Bottom;
     private static int MonitorLeft, MonitorTop, MonitorRight, MonitorBottom;
+
+    /**
+     * Deslocamentos dos campos que o hook precisa de ler. `Marshal.PtrToStructure` encaixotava a
+     * MSLLHOOKSTRUCT inteira a CADA evento; com um rato de 1000 Hz isso e lixo para o GC no unico
+     * thread por onde passa todo o rato do sistema. Ler tres campos soltos nao aloca nada.
+     */
+    private static readonly int OffsetPoint = (int)Marshal.OffsetOf(typeof(MSLLHOOKSTRUCT), "pt");
+    private static readonly int OffsetMouseData = (int)Marshal.OffsetOf(typeof(MSLLHOOKSTRUCT), "mouseData");
+    private static readonly int OffsetExtraInfo = (int)Marshal.OffsetOf(typeof(MSLLHOOKSTRUCT), "dwExtraInfo");
 
     /**
      * Captura do botao de disparo.
@@ -93,8 +113,23 @@ public static class ZenithRadialMouseBlocker {
     /** Uma pressao mais longa que isto foi intencao de abrir a roda, nao um clique. */
     private const long PASSTHROUGH_MAX_MS = 250;
 
+    /**
+     * Escrever no stdout a partir do hook e um risco real: se o pai parar de ler, o pipe enche e o
+     * `Console.WriteLine` BLOQUEIA -- e o thread bloqueado e justamente o que serve o hook, ou seja,
+     * congela o rato de todo o sistema ate ao `LowLevelHooksTimeout`. Enfileirar e devolver e sempre
+     * O(1); um thread dedicado faz a escrita.
+     */
     private static void Emit(string line) {
-        lock (WriteLock) { Console.WriteLine(line); Console.Out.Flush(); }
+        Outbound.Enqueue(line);
+        OutboundSignal.Set();
+    }
+
+    private static void DrainOutbound() {
+        string line;
+        while (Outbound.TryDequeue(out line)) {
+            Console.WriteLine(line);
+            Console.Out.Flush();
+        }
     }
 
     private static bool IsBlockedMessage(int message) {
@@ -123,23 +158,41 @@ public static class ZenithRadialMouseBlocker {
     private static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam) {
         if (nCode < 0) return CallNextHookEx(Hook, nCode, wParam, lParam);
 
-        var data = (MSLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(MSLLHOOKSTRUCT));
+        int message = wParam.ToInt32();
+
+        /**
+         * Todo o rato do sistema passa por aqui, serializado. O WM_MOUSEMOVE e a esmagadora maioria
+         * dos eventos (um rato gaming de 1000 Hz gera mil por segundo) e NUNCA e acionavel: nao esta
+         * em `IsBlockedMessage` nem em `TriggerFor`. Sair antes de tocar no lParam poupa o
+         * marshalling em ~99% dos eventos.
+         */
+        if (message == WM_MOUSEMOVE) return CallNextHookEx(Hook, nCode, wParam, lParam);
+
+        int trigger = TriggerButton;
+        bool blocking = Blocking;
+        /** Sem gatilho armado nem bloqueio ativo nao ha decisao nenhuma a tomar. */
+        if (trigger == 0 && !blocking) return CallNextHookEx(Hook, nCode, wParam, lParam);
+
+        ulong extraInfo = IntPtr.Size == 8
+            ? (ulong)Marshal.ReadInt64(lParam, OffsetExtraInfo)
+            : (ulong)(uint)Marshal.ReadInt32(lParam, OffsetExtraInfo);
 
         /** Os nossos proprios cliques devolvidos passam sem serem reinterpretados. */
-        if ((uint)data.dwExtraInfo.ToUInt64() == SYNTHETIC_TAG) {
+        if ((uint)extraInfo == SYNTHETIC_TAG) {
             return CallNextHookEx(Hook, nCode, wParam, lParam);
         }
 
-        int message = wParam.ToInt32();
-        int trigger = TriggerButton;
+        int px = Marshal.ReadInt32(lParam, OffsetPoint);
+        int py = Marshal.ReadInt32(lParam, OffsetPoint + 4);
 
         if (trigger != 0) {
             bool isDown;
-            int which = TriggerFor(message, data.mouseData, out isDown);
+            uint mouseData = (uint)Marshal.ReadInt32(lParam, OffsetMouseData);
+            int which = TriggerFor(message, mouseData, out isDown);
             if (which == trigger) {
                 if (isDown) {
-                    DownX = data.pt.x;
-                    DownY = data.pt.y;
+                    DownX = px;
+                    DownY = py;
                     DownAt = Environment.TickCount;
                     Emit("TRIGGER_DOWN");
                 } else {
@@ -149,8 +202,8 @@ public static class ZenithRadialMouseBlocker {
                      * botao do meio. Devolvemos o clique a janela por baixo -- mas fora do hook,
                      * porque injetar aqui reentraria nele.
                      */
-                    int dx = data.pt.x - DownX;
-                    int dy = data.pt.y - DownY;
+                    int dx = px - DownX;
+                    int dy = py - DownY;
                     long held = Environment.TickCount - DownAt;
                     int threshold = TriggerThreshold;
                     if (TriggerHoldMode && held <= PASSTHROUGH_MAX_MS &&
@@ -162,10 +215,10 @@ public static class ZenithRadialMouseBlocker {
             }
         }
 
-        if (Blocking && IsBlockedMessage(message)) {
-            bool insideAllowed = data.pt.x >= Left && data.pt.x < Right && data.pt.y >= Top && data.pt.y < Bottom;
-            bool insideMonitor = data.pt.x >= MonitorLeft && data.pt.x < MonitorRight &&
-                                 data.pt.y >= MonitorTop && data.pt.y < MonitorBottom;
+        if (blocking && IsBlockedMessage(message)) {
+            bool insideAllowed = px >= Left && px < Right && py >= Top && py < Bottom;
+            bool insideMonitor = px >= MonitorLeft && px < MonitorRight &&
+                                 py >= MonitorTop && py < MonitorBottom;
             if (insideMonitor && !insideAllowed) return new IntPtr(1);
         }
 
@@ -258,6 +311,16 @@ public static class ZenithRadialMouseBlocker {
 
     public static void Run(int parentPid) {
         var context = new ApplicationContext();
+
+        var output = new Thread(() => {
+            while (true) {
+                OutboundSignal.WaitOne();
+                DrainOutbound();
+            }
+        });
+        output.IsBackground = true;
+        output.Start();
+
         var input = new Thread(() => {
             string line;
             while ((line = Console.ReadLine()) != null) Commands.Enqueue(line);
@@ -266,11 +329,33 @@ public static class ZenithRadialMouseBlocker {
         input.IsBackground = true;
         input.Start();
 
+        /**
+         * Vigia do pai SEM sondagem.
+         *
+         * O tick do timer chamava `Process.GetProcessById(parentPid)`. No Windows PowerShell
+         * (.NET Framework) essa chamada tira um retrato de TODA a tabela de processos: medidos
+         * ~12 ms com 350 processos -- num timer de 15 ms, ou seja, 80% do tempo ocupado. E o timer
+         * corre no MESMO thread que serve o hook WH_MOUSE_LL, por onde o Windows serializa todo o
+         * rato do sistema. Resultado: o ecra inteiro engasgava, nao so o radial.
+         *
+         * Um handle SYNCHRONIZE mais `WaitForSingleObject` deteta a morte do pai instantaneamente e
+         * nao custa absolutamente nada enquanto ele estiver vivo.
+         */
+        var parentWatch = new Thread(() => {
+            IntPtr handle = OpenProcess(SYNCHRONIZE, false, parentPid);
+            /** Se o handle falhar, o EOF do stdin continua a ser a rede de seguranca. */
+            if (handle == IntPtr.Zero) return;
+            WaitForSingleObject(handle, INFINITE);
+            CloseHandle(handle);
+            Commands.Enqueue("EXIT");
+        });
+        parentWatch.IsBackground = true;
+        parentWatch.Start();
+
+        /** So esvaziar filas: microssegundos por tick, ao contrario do retrato de processos. */
         var timer = new System.Windows.Forms.Timer();
         timer.Interval = 15;
         timer.Tick += (sender, args) => {
-            try { Process.GetProcessById(parentPid); }
-            catch { Commands.Enqueue("EXIT"); }
             string command;
             while (Commands.TryDequeue(out command)) Apply(command, context);
             int passthrough;
@@ -282,6 +367,7 @@ public static class ZenithRadialMouseBlocker {
         timer.Stop();
         TriggerButton = 0;
         DisableBlocking();
+        DrainOutbound();
     }
 }
 "@


### PR DESCRIPTION
The radial trigger is a global `WH_MOUSE_LL` hook. Windows serializes all desktop mouse input through it on the installing thread, so anything slow there stalls the whole system's pointer. Three things were:

- **15 ms watchdog** — `Process.GetProcessById` on .NET Framework snapshots every process via `NtQuerySystemInformation`: 12.2 ms per call at 355 processes. Now `OpenProcess(SYNCHRONIZE)` + `WaitForSingleObject` on its own thread.
- **Per-event marshalling** — `PtrToStructure` boxed an `MSLLHOOKSTRUCT` on every event, `WM_MOUSEMOVE` included (~1000/s, never actionable). Now early-outs, then reads the three needed fields by offset.
- **`Emit()`** — blocking `Console.WriteLine` + `Flush`; a full pipe would freeze system-wide input until `LowLevelHooksTimeout`. Now enqueue + writer thread.

Hook armed, app idle: **63.0% → 0.0% of one core.**

Also: moved `ensureRadialMouseBlocker()` below the single-instance guard (a rejected instance left a stray hook host), and fixed comments claiming the trigger polls `GetAsyncKeyState` rather than using `WH_MOUSE_LL` — the reverse, and it hid this fault through several lag investigations.

Tested on Windows 10 19045, 239 Hz: idle CPU, trigger down/up, short-press passthrough, bounds blocking, teardown on parent exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
